### PR TITLE
fix: not getting discord info till resource gets restarted

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -99,7 +99,7 @@ AddEventHandler("playerConnecting", function(name, setKickReason, deferrals)
     deferrals.defer()
     Wait(0)
 
-    if mainIdentifier and Config.discordBotToken ~= "false" and Config.discordGuildId ~= "false" and not discordInfo then
+    if mainIdentifier and Config.discordBotToken ~= "false" and Config.discordGuildId ~= "false" and next(discordInfo) == nil then
         discordInfo = checkDiscordIdentifier(identifiers)
         if not discordInfo then
             deferrals.done(("Your discord was not found, join our discord here: %s."):format(Config.discordInvite))

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,6 +3,7 @@ NDCore.players = {}
 PlayersInfo = {}
 local resourceName = GetCurrentResourceName()
 local tempPlayersInfo = {}
+local next = next
 
 Config = {
     serverName = GetConvar("core:serverName", "Unconfigured ND-Core Server"),

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,7 +3,6 @@ NDCore.players = {}
 PlayersInfo = {}
 local resourceName = GetCurrentResourceName()
 local tempPlayersInfo = {}
-local next = next
 
 Config = {
     serverName = GetConvar("core:serverName", "Unconfigured ND-Core Server"),
@@ -95,12 +94,12 @@ AddEventHandler("playerConnecting", function(name, setKickReason, deferrals)
     local tempSrc = source
     local identifiers = getIdentifierList(tempSrc)
     local mainIdentifier = identifiers[Config.characterIdentifier]
-    local discordInfo = {}
+    local discordInfo = nil
 
     deferrals.defer()
     Wait(0)
 
-    if mainIdentifier and Config.discordBotToken ~= "false" and Config.discordGuildId ~= "false" and next(discordInfo) == nil then
+    if mainIdentifier and Config.discordBotToken ~= "false" and Config.discordGuildId ~= "false" then
         discordInfo = checkDiscordIdentifier(identifiers)
         if not discordInfo then
             deferrals.done(("Your discord was not found, join our discord here: %s."):format(Config.discordInvite))


### PR DESCRIPTION
_fixes #45_
in the `playerConnecting` event, `discordInfo` was **always** being returned as `true` because the table existed, whether it was empty or not. this caused the if statement that would run `checkDiscordIdentifier` to always be skipped due to it requiring `discordInfo` to be `false`, preventing the proper retrieval of any discord identifier data. the changes i have made will fix that by using `next` to check if the table is empty.
also added `next` as a local for optimization