### PR TITLE
feat: receive groups by discord roles

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -24,6 +24,7 @@ Config = {
     groups = json.decode(GetConvar("core:groups", "[]")),
     admins = json.decode(GetConvar("core:admins", "[]")),
     adminDiscordRoles = json.decode(GetConvar("core:adminDiscordRoles", "[]")),
+    groupRoles = json.decode(GetConvar("core:groupRoles", "[]")),
     multiCharacter = false,
     compatibility = json.decode(GetConvar("core:compatibility", "[]"))
 }

--- a/server/player.lua
+++ b/server/player.lua
@@ -309,6 +309,12 @@ local function createCharacterTable(info)
                     self.addGroup("admin")
                 end
             end
+            
+            for group, role in pairs(Config.groupRoles)
+                if lib.table.contains(roles, role) then
+                    self.addGroup(group)
+                end
+            end
         end
 
         for name, _ in pairs(self.groups) do


### PR DESCRIPTION
Player can receive groups based on the discord roles they have, ace perms are also added when group is received.