### PR TITLE
fix: missing return

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -9,3 +9,5 @@ NDCore = setmetatable({}, {
         return self[index]
     end
 })
+
+return NDCore


### PR DESCRIPTION
this fixes the issue that ND_Ambulance is having with ND_Core, caused by it using `local NDCore = require "@ND_Core.init"`, which currently just returns a boolean due to the missing return