### PR TITLE
Fix duplicate 'gender' entry in user object

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -24,8 +24,7 @@ function NDCore.getPlayers(key, value, returnArray)
         lastname = "lastname",
         gender = "gender",
         groups = "groups",
-        job = "job",
-        gender = "gender"
+        job = "job"
     }
 
     local findBy = keyTypes[key] or "metadata"


### PR DESCRIPTION
This PR removes the duplicate "gender" entry from key types in the `getPlayers` function.